### PR TITLE
Maintenance 6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 
 Tags: notification, news, posts, permalink, url  
-Contributors: tarosky, Takahashi_Fumiki  
+Contributors: tarosky, Takahashi_Fumiki, tswallie  
 Tested up to: 6.8  
 Stable Tag: nightly  
 License: GPLv3 or later  
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
 
-A WordPress plugin to allow some posts to have external permalink.
+A WordPress plugin that allows selected post types to redirect to external URLs.
 
 ## Description
 
-This plugin adds an "External Link" section to your editor.
+This plugin adds an "External Link" section to the post editor.
 
-If you have posts that are mainly used to link to news articles on other websites, this plugin will override the post's permalink, redirecting users who click on the post directly to the source.
+If you're publishing posts that are primarily used to link to external news articles or resources, the plugin overrides the post’s permalink and redirects users to the specified external URL when they click the post.
 
 The "External Link" section has two options:
 
@@ -27,33 +27,39 @@ By setting an external link, the link in your widget, post archive and so on, wi
 
 This plugin adds a new section to Writing Settings with 3 different options.
 
-#### Post Types
+#### 1. Post Types
 
-Lets you select which Post Types are allowed to have an external link.
+Lets you select which post types should support external links.
 
-#### Attributes
+#### 2. Attributes
 
 When set to Automatic, the target and rel attributes will be automatically added to anchor elements linking to the new URL, using jQuery.
 
-When set to Manual, developers are expected to add anchors manually. You can either use `tsep_anchor_attributes()` to generate the href, rel and target attributes, or use `the_permalink()` to populate the href attribute and `tsep_target_attributes()` to add the target and rel attributes separately.
+When set to Manual, developers must manually add anchor elements. You can either use `tsep_anchor_attributes()` to generate the href, rel and target attributes, or use `the_permalink()` to populate the href attribute and `tsep_target_attributes()` to add the target and rel attributes separately.
 
-<pre>
-&lt;a &lt;?php echo tsep_anchor_attributes(); ?&gt; class="some-class"&gt;Click here!&lt;/a&gt;
-</pre>
+**Easy method:**
+```php
+<a <?php echo tsep_anchor_attributes(123); ?> class="some-class">Click here!</a>
+```
 
-#### Single Page Content
+**With separate attributes:**
+```php
+<a href="<?php echo the_permalink(123); ?>" <?php echo tsep_anchor_attributes(123); ?> class="some-class">Click here!</a>
+```
+
+#### 3. Single Page Content
 
 This option allows you to manually write an anchor element that will be added to the post's content. Use %link% for the external link, and %rel% for the target and rel attributes.
 
-<pre>
-&lt;a href="%link%"%ref%&gt;Click here!&lt;/a&gt;
-</pre>
+```php
+<a href="%link%" %rel%>Click here!</a>
+```
 
 This will produce the following output:
 
-<pre>
-&lt;a href="https://example.com" rel="noopener noreferrer" target="_black"&gt;Click here!&lt;/a&gt;
-</pre>
+```php
+<a href="https://example.com" rel="noopener noreferrer" target="_blank">Click here!</a>
+```
 
 ## Installation
 
@@ -61,7 +67,7 @@ This will produce the following output:
 
 Click install and activate it.
 
-### From Github
+### From GitHub
 
 See [releases](https://github.com/tarosky/taro-external-permalink/releases).
 
@@ -69,7 +75,7 @@ See [releases](https://github.com/tarosky/taro-external-permalink/releases).
 
 ### Where can I get supported?
 
-Please create new ticket on support forum.
+Please create new ticket on the support forum.
 
 ### How can I contribute?
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,48 @@ A WordPress plugin to allow some posts to have external permalink.
 
 ## Description
 
-This plugin add "External Link" section to your editor.
+This plugin adds an "External Link" section to your editor.
 
-If your posts are used as news in your site, sometimes a post is titled simply "Our service is promoted in famous web magazine" and just having a single link to PR site.
+If you have posts that are mainly used to link to news articles on other websites, this plugin will override the post's permalink, redirecting users who click on the post directly to the source.
 
-This plugin will add a meta box to save metadata below:
+The "External Link" section has two options:
 
-1. External link
-2. Open in new window
+1. External link (This URL will replace the return value of `the_permalink`)
+2. Open in new window (checkbox)
 
-If you set external link, `the_permalink` will be replaced with it. The link in your widget, post archive, and so on will refer to the URL you saved.
+By setting an external link, the link in your widget, post archive and so on, will refer to the new URL you saved.
+
+### Settings
+
+This plugin adds a new section to Writing Settings with 3 different options.
+
+#### Post Types
+
+Lets you select which Post Types are allowed to have an external link.
+
+#### Attributes
+
+When set to Automatic, the target and rel attributes will be automatically added to anchor elements linking to the new URL, using jQuery.
+
+When set to Manual, developers are expected to add anchors manually. You can either use `tsep_anchor_attributes()` to generate the href, rel and target attributes, or use `the_permalink()` to populate the href attribute and `tsep_target_attributes()` to add the target and rel attributes separately.
+
+<pre>
+&lt;a &lt;?= tsep_anchor_attributes() ?&gt; class="some-class"&gt;Click here!&lt;/a&gt;
+</pre>
+
+#### Single Page Content
+
+This option allows you to manually write an anchor element that will be added to the post's content. Use %link% for the external link, and %rel% for the target and rel attributes.
+
+<pre>
+&lt;a href="%link%"%ref%&gt;Click here!&lt;/a&gt;
+</pre>
+
+This will produce the following output:
+
+<pre>
+&lt;a href="https://example.com" rel="noopener noreferrer" target="_black"&gt;Click here!&lt;/a&gt;
+</pre>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ When set to Automatic, the target and rel attributes will be automatically added
 When set to Manual, developers are expected to add anchors manually. You can either use `tsep_anchor_attributes()` to generate the href, rel and target attributes, or use `the_permalink()` to populate the href attribute and `tsep_target_attributes()` to add the target and rel attributes separately.
 
 <pre>
-&lt;a &lt;?= tsep_anchor_attributes() ?&gt; class="some-class"&gt;Click here!&lt;/a&gt;
+&lt;a &lt;?php echo tsep_anchor_attributes(); ?&gt; class="some-class"&gt;Click here!&lt;/a&gt;
 </pre>
 
 #### Single Page Content

--- a/includes/editor.php
+++ b/includes/editor.php
@@ -47,7 +47,7 @@ add_action( 'add_meta_boxes', function ( $post_type ) {
 		wp_nonce_field( 'tsep_save_post', '_tsepnonce' );
 		?>
 		<p class="description">
-			<?php esc_html_e( 'If external permalink is set, the url of this post will be replaced.', 'tsep' ); ?>
+			<?php esc_html_e( 'Overrides the post’s permalink, redirecting clicks to this URL instead.', 'tsep' ); ?>
 		</p>
 		<p>
 			<label>

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -36,7 +36,7 @@ function tsep_is_active( $post_type ) {
  * @return string
  */
 function tsep_link_text( $return_default = false ) {
-	$default_label = __( 'For more details please refer to <a href="%link%"%rel%>here</a>.', 'tsep' );
+	$default_label = __( 'For more details please refer to <a href="%link%" %rel%>here</a>.', 'tsep' );
 	if ( $return_default ) {
 		return $default_label;
 	}
@@ -54,7 +54,7 @@ add_action( 'admin_init', function () {
 	add_settings_section( 'tsep-setting', __( 'External Permalink', 'tsep' ), function () {
 		printf(
 			'<p id="tsep-setting" class="description">%s</p>',
-			esc_html__( 'This section determine which post type can have external permalink.', 'tsep' )
+			esc_html__( 'This section lets you select which post types should support external links.', 'tsep' )
 		);
 	}, 'writing' );
 	// Add fields.

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -36,7 +36,7 @@ function tsep_is_active( $post_type ) {
  * @return string
  */
 function tsep_link_text( $return_default = false ) {
-	$default_label = __( 'Please refer detail at <a href="%link%"%rel%>here</a>.', 'tsep' );
+	$default_label = __( 'For more details please refer to <a href="%link%"%rel%>here</a>.', 'tsep' );
 	if ( $return_default ) {
 		return $default_label;
 	}
@@ -84,12 +84,10 @@ add_action( 'admin_init', function () {
 	// Register.
 	register_setting( 'writing', 'tsep_post_types' );
 	// Add fields.
-	add_settings_field( 'tsep_render_type', __( 'Attribues', 'tsep' ), function () {
+	add_settings_field( 'tsep_render_type', __( 'Attributes', 'tsep' ), function () {
 		$options = [
-			''             => __( 'No(writing code)', 'tsep' ),
-			'double-quote' => __( 'Hook the_permalink(permalink is wrapped in double quote.)', 'tsep' ),
-			'single-quote' => __( 'Hook the_permalink(permalink is wrapped in single quote.)', 'tsep' ),
-			'automatic'    => __( 'Automatic', 'tesp' ),
+			'automatic' => __( 'Automatic', 'tsep' ),
+			'manual'    => __( 'Manual', 'tsep' ),
 		];
 		?>
 		<select name="tsep_render_type">
@@ -109,7 +107,9 @@ add_action( 'admin_init', function () {
 			'<p class="description">%s</p>',
 			sprintf(
 				// translators: %s is function.
-				esc_html__( 'Please select how to render target and rel attributes. Function %s is also available.', 'tsep' ),
+				esc_html__( 'When using Manual mode, use %1$s inside an anchor element to generate href, rel and target attributes. Or use %2$s to populate the href attribute and %3$s to add the target and rel attributes separately.', 'tsep' ),
+				'<code>tsep_anchor_attributes()</code>',
+				'<code>the_permalink()</code>',
 				'<code>tsep_target_attributes()</code>'
 			)
 		);
@@ -126,7 +126,7 @@ add_action( 'admin_init', function () {
 		<?php
 		printf(
 			'<p class="description">%s</p>',
-			esc_html__( 'On singular page, post content will be replaced with this content. %link% will be replaced to external link and %rel% will be replaced with target and rel attributes..', 'tsep' )
+			esc_html__( 'On a single post page, this will be added to the post\'s content. %link% will be replaced with the external link, and %rel% with the target and rel attributes.', 'tsep' )
 		);
 	}, 'writing', 'tsep-setting' );
 	// Register.

--- a/includes/templates.php
+++ b/includes/templates.php
@@ -25,13 +25,28 @@ function tsep_target_attributes( $post = null, $rel = true, $quote = '"' ) {
 		'target' => '_blank',
 	];
 	if ( $rel ) {
-		$attributes['rel'] = 'noopner noreferrer';
+		$attributes['rel'] = 'noopener noreferrer';
 	}
 	$html = [];
 	foreach ( $attributes as $attr => $value ) {
 		$html[] = sprintf( '%1$s=%3$s%2$s%3$s', $attr, esc_attr( $value ), $quote );
 	}
-	return implode( ' ', $attributes );
+	return implode( ' ', $html );
+}
+
+/**
+ * Get anchor attributes.
+ *
+ * @param null|int|WP_Post $post Post object.
+ * @return string
+ */
+function tsep_anchor_attributes( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post || ! tsep_is_active( $post->post_type ) ) {
+		return '';
+	}
+	$link = tsep_get_url( $post );
+	return 'href="' . $link . '" ' . tsep_target_attributes( $post );
 }
 
 /**
@@ -79,23 +94,8 @@ add_filter( 'the_permalink', function ( $link, $post ) {
 	if ( ! $post || ! tsep_is_active( $post->post_type ) ) {
 		return $link;
 	}
-	if ( ! tsep_is_new_window( $post ) ) {
-		return $link;
-	}
-	// Depends on render type.
-	$render_type = get_option( 'tsep_render_type', '' );
-	switch ( $render_type ) {
-		case 'single-quote':
-			$quote = "'";
-			break;
-		case 'double-quote':
-			$quote = '"';
-			break;
-		default:
-			return $link;
-	}
-	$attr = rtrim( tsep_target_attributes( $post, true, $quote ), $quote );
-	return $link . $quote . ' ' . $attr;
+	$link = tsep_get_url( $post );
+	return $link;
 }, 10, 2);
 
 /**

--- a/includes/templates.php
+++ b/includes/templates.php
@@ -75,28 +75,13 @@ function tsep_post_link_filter( $permalink, $post ) {
 	if ( ! is_admin() && tsep_is_active( $post->post_type ) ) {
 		$url = tsep_get_url( $post );
 		if ( $url ) {
-			if ( tsep_is_new_window( $post ) ) {
-				tsep_url_store( $permalink, $url );
-			}
-			$permalink = $url;
+			return $url;
 		}
 	}
 	return $permalink;
 }
 add_filter( 'post_link', 'tsep_post_link_filter', 10, 2 );
 add_filter( 'post_type_link', 'tsep_post_link_filter', 10, 2 );
-
-/**
- * If permalink is changes, add rel.
- */
-add_filter( 'the_permalink', function ( $link, $post ) {
-	$post = get_post( $post );
-	if ( ! $post || ! tsep_is_active( $post->post_type ) ) {
-		return $link;
-	}
-	$link = tsep_get_url( $post );
-	return $link;
-}, 10, 2);
 
 /**
  * Change content of singular page.


### PR DESCRIPTION
属性オプションの目的を理解するのは非常に難しかったのですが、以下が私の解釈です：

**No (Writing code)**
テーマに手動でアンカーを追加することを前提とします。the_permalink と、おそらく tsep_target_attributes を使用します：
`<a href="<?php the_permalink(123) ?>" <?= tsep_target_attributes() ?>>Click here</a>`

**Hook the_permalink (permalink is wrapped in double quote.)**
テーマに手動でアンカーを追加することを前提としますが、the_permalink の戻り値に属性をダブルクォーテーション付きで挿入します：
`<a href="<?php the_permalink(123) ?>">Click here</a>`

**Hook the_permalink (permalink is wrapped in single quote.)**
テーマに手動でアンカーを追加することを前提としますが、the_permalink の戻り値に属性をシングルクォーテーション付きで挿入します：
`<a href='<?php the_permalink(123) ?>'>Click here</a>`

**Automatic**
フロントエンドで jQuery を使用して、external URL へのすべてのアンカーに target および rel 属性を追加します。

### なぜ動かなかった

最初の3つのオプションが機能しなかった理由はいくつかあります：

1. 元のリンクを返しており、新しい external URL を返していなかった。
2. `rel` 属性の綴りが間違っていた。
3. WordPress は `the_permalink` が URL を返すことを前提としているため、特殊文字が `%20` などのスペースとしてエンコードされてしまった。

### 解決策

`the_permalink` を、`href` 属性に使うことを想定した文字列に置き換えつつ、他の属性も追加するという方法は非常に不安定でエラーが起きやすい汚い修正方法だったため、最初の3つのオプションを `Manual` というオプションに置き換えました。また、アンカー要素内で使用できる `tsep_anchor_attributes()` という関数も追加しました。これにより、`href`、`rel`、`target` を一度に生成できます。

そのため、`Manual` を選択した場合、開発者は以下のようにアンカーを書くことができます：

<pre>
&lt;a &lt;?= tsep_anchor_attributes() ?&gt; class="some-class"&gt;Click here!&lt;/a&gt;
</pre>

または、以下のようにも書けます：

<pre>
&lt;a href="&lt;?php the_permalink() ?&gt;" &lt;?= tsep_target_attributes() ?&gt; class="some-class"&gt;Click here!&lt;/a&gt;
</pre>

### 最後に

いくつかのUIテキストを書き直して、より分かりやすくしました。また、READMEも更新し、各オプションの簡単な説明を追加しました。