### PR TITLE
Add <file> targets to phpcs config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
 	"minimum-stability": "stable",
 	"license": "GPL-3.0-or-later",
 	"scripts": {
-		"lint":  "phpcs --standard=phpcs.ruleset.xml $(find ./ -name '*.php')",
-		"fix": "phpcbf --standard=phpcs.ruleset.xml $(find ./ -name '*.php')",
+		"lint": "phpcs --standard=phpcs.ruleset.xml",
+		"fix": "phpcbf --standard=phpcs.ruleset.xml",
 		"phpstan": "phpstan analyse --memory-limit=1G",
 		"test": "phpunit"
 	},

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -27,6 +27,9 @@
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
 	</rule>
 
+	<file>taro-external-permalink.php</file>
+	<file>includes</file>
+
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*.js</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>


### PR DESCRIPTION
## Summary

- `phpcs.ruleset.xml` に `<file>` タグを追加し、対象ファイル/ディレクトリを明示指定
- `composer.json` の `lint` / `fix` スクリプトから `$(find)` や明示的パス指定を削除し、phpcs の設定に委譲
- taro-open-hour のリファレンス実装に準拠

## Why

GitHub Actions 環境で `find` コマンドの引数が多すぎてエラーになる問題を解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)