### PR TITLE
Add weekly issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,20 @@
+name: Issue Triage
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'  # 毎週月曜 01:00 UTC
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "何日以内に作成されたIssueを対象にするか（デフォルト: 30）"
+        required: false
+        type: string
+        default: '30'
+
+jobs:
+  triage:
+    uses: tarosky/workflows/.github/workflows/issue-triage.yml@main
+    with:
+      plugin_name: external-permalink
+      days: ${{ fromJSON(inputs.days || '30') }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- 毎週月曜 01:00 UTC に未トリアージのIssueを自動分類する `issue-triage.yml` を追加
- `tarosky/workflows/.github/workflows/issue-triage.yml@main` 共有ワークフローを呼び出し
- ラベル付与（bug/enhancement/question/wontfix/duplicate）+ 日本語コメント
- `workflow_dispatch` で手動実行も可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)